### PR TITLE
Fix asynchronous bulk creation of cities

### DIFF
--- a/api/scripts/database_initial_data.py
+++ b/api/scripts/database_initial_data.py
@@ -99,7 +99,7 @@ async def run():
                     name=municipio['Nome_Município']
                 )
             )
-    City.bulk_create(cities_to_create, ignore_conflicts=True)
+    await City.bulk_create(cities_to_create, ignore_conflicts=True)
     logger.info("States and Cities created successfully")
 
     await Tortoise.close_connections()


### PR DESCRIPTION
- Bugfix: Faltou o "await" no comando de bulk create das cidades. 
   - Não gerava erros, mas não inseria na tabela de cidades 